### PR TITLE
Some Summit Fixes

### DIFF
--- a/cuda/linear.hpp
+++ b/cuda/linear.hpp
@@ -60,7 +60,7 @@ public:
         using DeviceImageType = device_image<3,typename ImageType::value_type>;
         if(from_raw.size() > to_raw.size())
         {
-            auto inv_trans(trans);
+            TransformType inv_trans(trans);
             inv_trans.inverse();
             return (*this)(to_raw,from_raw,inv_trans);
         }

--- a/numerical/numerical.hpp
+++ b/numerical/numerical.hpp
@@ -694,7 +694,8 @@ minmax_value(iterator_type iter,iterator_type end)
 
 //---------------------------------------------------------------------------
 template<typename iterator_type>
-auto minmax_value_mt(iterator_type iter,iterator_type end)
+std::pair<typename std::iterator_traits<iterator_type>::value_type,typename std::iterator_traits<iterator_type>::value_type>
+minmax_value_mt(iterator_type iter,iterator_type end)
 {
     using value_type = typename std::iterator_traits<iterator_type>::value_type;
     if(iter == end)
@@ -778,7 +779,9 @@ void upper_lower_threshold(ImageType& data,value_type lower,value_type upper)
 template<typename InputIter,typename OutputIter>
 void normalize_upper_lower(InputIter from,InputIter to,OutputIter out,float upper_limit = 255.0)
 {
-    auto min_max(minmax_value(from,to));
+		using MinMaxType = typename std::iterator_traits<InputIter>::value_type;
+
+    std::pair<MinMaxType,MinMaxType> min_max(minmax_value(from,to));
     auto range = min_max.second-min_max.first;
     if(range == 0)
         return;
@@ -803,7 +806,9 @@ void normalize_upper_lower(ImageType& I,float upper_limit = 255.0)
 template<typename InputIter,typename OutputIter>
 void normalize_upper_lower_mt(InputIter from,InputIter to,OutputIter out,float upper_limit = 255.0)
 {
-    auto min_max(minmax_value_mt(from,to));
+		using MinMaxType = typename std::iterator_traits<InputIter>::value_type;
+
+    std::pair<MinMaxType,MinMaxType> min_max(minmax_value_mt(from,to));
     auto range = min_max.second-min_max.first;
     if(range == 0)
         return;

--- a/reg/linear.hpp
+++ b/reg/linear.hpp
@@ -59,7 +59,7 @@ public:
     {
         if(from_.size() > to_.size())
         {
-            auto trans(transform);
+            TransformType trans(transform);
             trans.inverse();
             return (*this)(to_,from_,trans);
         }

--- a/utility/basic_image.hpp
+++ b/utility/basic_image.hpp
@@ -181,7 +181,10 @@ public:
     template<typename T,typename std::enable_if<T::dimension==dimension && !std::is_same<storage_type,typename T::storage_type>::value,bool>::type = true>
     __INLINE__ image& operator=(const T& rhs)
     {
-        storage_type new_alloc(rhs.begin(),rhs.end());
+				using TIteratorType = typename T::const_iterator;
+				// Casting is needed here, because if rhs is a device vector, rhs.begin() is a void * and this 
+				// will later lead to a reference to void
+        storage_type new_alloc(static_cast<TIteratorType>(rhs.begin()),static_cast<TIteratorType>(rhs.end()));
         alloc.swap(new_alloc);
         sp = rhs.shape();
         return *this;


### PR DESCRIPTION
I have a few fixes to allow building on Summit using PPC64 GCC-11.1.0 and CUDA/11.4.2.
Mostly relating to things like auto-deduction in GCC, and to deal with void* etc.